### PR TITLE
Add caching to json data

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -40,6 +40,20 @@ func getFellowHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Check if user was already queried
+	if CheckUser(vars["username"]) {
+		// TODO: get json data here
+
+		endPoint := fmt.Sprintf("/getfellow/%s", vars["username"])
+		logCall("POST", endPoint, "200", startTime)
+		w.WriteHeader(http.StatusOK)
+		// fmt.Fprintf(w, string(jsonData))
+		fmt.Fprintf(w, "User found, using cached data") // TODO: add real json data here
+
+		return
+	}
+
+	// Query user data
 	httpClient := SetupOAuth()
 	client := graphql.NewClient("https://api.github.com/graphql", httpClient)
 
@@ -71,6 +85,7 @@ func main() {
 	r.HandleFunc("/", homeHandler).Methods("GET")
 	r.HandleFunc("/getfellow/{username}", getFellowHandler).Methods("POST")
 
+	log.Println("Starting web server on localhost:8080")
 	http.ListenAndServe(":8080", r)
 
 	// httpClient := SetupOAuth()


### PR DESCRIPTION
1. Checks if a user is already queried. If so, grab the data from it. 
2. Users are checked by looking at their directories on `data/{username}`. A new user directory is created if none is found. 
3. If a directory for a user is found but it's empty, remove the directory and do the query normally.

Related to #11.

**Obs**: `main.go` should be ran from directory root so that `CheckUser` can find the `data/{username}` directories.