### PR TITLE
Username input queries

### DIFF
--- a/backend/queries.go
+++ b/backend/queries.go
@@ -92,7 +92,7 @@ type issuesClosed struct {
 				Url   graphql.String
 			} `graphql:"... on Issue"`
 		}
-	} `graphql:"search(query: \"is:issue state:closed author:@me created:2020-06-01..2020-08-30\", type: ISSUE, first: 100)"`
+	} `graphql:"search(query: "is:issue state:closed author:$username created:2020-06-01..2020-08-30", type: ISSUE, first: 20)"`
 }
 
 type accountInformation struct {
@@ -104,7 +104,7 @@ type accountInformation struct {
 		Location   graphql.String
 		Url        graphql.String
 		WebsiteUrl graphql.String
-	} `graphql:"user(login: \"IamCathal\")"`
+	} `graphql:"user(login: $username)"`
 }
 
 func writeJSON(jsonStruct megaJSONStruct) {

--- a/backend/queries.go
+++ b/backend/queries.go
@@ -65,34 +65,27 @@ type repositoriesContributedTo struct {
 	}
 }
 
-type pullRequestsOpened struct {
-	Search struct {
-		IssueCount graphql.Int
-	} `graphql:"search(query: \"is:pr author:@me created:2020-06-01..2020-08-30\", type: ISSUE, first: 100)"`
+type pullRequests struct {
+	User struct {
+		PullRequests struct {
+			Nodes []struct {
+				CreatedAt graphql.String
+				Merged    graphql.Boolean
+			}
+		} `graphql:"pullRequests(first:60 orderBy:{direction:DESC field:CREATED_AT})"`
+	} `graphql:"user(login: $username)"`
 }
 
-type pullRequestsMerged struct {
-	Search struct {
-		IssueCount graphql.Int
-	} `graphql:"search(query: \"is:pr author:@me merged:2020-06-01..2020-08-30\", type: ISSUE, first: 100)"`
-}
-
-type issuesOpened struct {
-	Search struct {
-		IssueCount graphql.Int
-	} `graphql:"search(query: \"is:issue author:@me created:2020-06-01..2020-08-30\", type: ISSUE, first: 100)"`
-}
-
-type issuesClosed struct {
-	Search struct {
-		IssueCount graphql.Int
-		Nodes      []struct {
-			Issue struct {
-				Title graphql.String
-				Url   graphql.String
-			} `graphql:"... on Issue"`
-		}
-	} `graphql:"search(query: "is:issue state:closed author:$username created:2020-06-01..2020-08-30", type: ISSUE, first: 20)"`
+type issuesCreated struct {
+	User struct {
+		Issues struct {
+			TotalCount graphql.Int
+			Nodes      []struct {
+				CreatedAt graphql.String
+				Closed    graphql.Boolean
+			}
+		} `graphql:"issues(first:60 orderBy:{direction:DESC field:CREATED_AT} filterBy:{since:"2020-06-01T00:00:00Z"})"`
+	} `graphql:"user(login: $username)"`
 }
 
 type accountInformation struct {

--- a/backend/util.go
+++ b/backend/util.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -91,10 +90,7 @@ func SetupOAuth() *http.Client {
 	return httpClient
 }
 
-func logCall(method, endpoint, status string, startTime int64) {
-	endTime := time.Now().UnixNano() / int64(time.Millisecond)
-	roundTripTime := endTime - startTime
-	delay := strconv.FormatInt(roundTripTime, 10)
+func logCall(method, endpoint, status string) {
 	statusColor := "\033[0m"
 
 	// If the HTTP status given is 2XX, give it a nice
@@ -104,7 +100,7 @@ func logCall(method, endpoint, status string, startTime int64) {
 	} else {
 		statusColor = "\033[31m"
 	}
-	fmt.Printf("[%s] %s %s %s%s%s %sms\n", time.Now().Format("02-Jan-2006 15:04:05"), method, endpoint, statusColor, status, "\033[0m", delay)
+	fmt.Printf("[%s] %s %s %s%s%s\n", time.Now().Format("02-Jan-2006 15:04:05"), method, endpoint, statusColor, status, "\033[0m")
 }
 
 func isValidUsername(username string) bool {


### PR DESCRIPTION
Change queries to take in `username` instead of using `viewer`. This allows us to query data for a user having only the `username` instead of the user's API key.