### PR TITLE
Server refactor

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -17,12 +17,7 @@ func main() {
 
 	r := mux.NewRouter()
 	r.HandleFunc("/", server.HomeHandler).Methods("GET")
-	r.HandleFunc("/accountinfo/{username}", server.GetFellowAccountInfo).Methods("POST")
-	r.HandleFunc("/issuescreated/{username}", server.GetFellowIssuesCreated).Methods("POST")
-	r.HandleFunc("/pullrequests/{username}", server.GetFellowPullRequests).Methods("POST")
-	r.HandleFunc("/repocontributedto/{username}", server.GetFellowRepoContributions).Methods("POST")
-	r.HandleFunc("/pullrequestcommits/{username}", server.GetFellowPullRequestCommits).Methods("POST")
-	r.HandleFunc("/prcontributions/{username}", server.GetFellowLinesOfCodeInPRs).Methods("POST")
+	r.HandleFunc("/{query}/{username}", server.Query).Methods("POST")
 	r.Use(server.VerificationMiddleware)
 
 	log.Println("Starting web server on localhost:8080")

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -31,7 +31,7 @@ func VerificationMiddleware(next http.Handler) http.Handler {
 			}
 			json.NewEncoder(w).Encode(res)
 
-			util.LogCall(r.Method, r.RequestURI, "401")
+			util.LogCall(r.Method, r.RequestURI, "401", false)
 			return
 		}
 
@@ -43,8 +43,7 @@ func VerificationMiddleware(next http.Handler) http.Handler {
 				Body:   fmt.Sprint(err),
 			}
 			json.NewEncoder(w).Encode(res)
-
-			util.LogCall(r.Method, r.RequestURI, "400")
+			util.LogCall(r.Method, r.RequestURI, "400", false)
 			return
 		}
 
@@ -63,7 +62,7 @@ func HomeHandler(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(res)
-	util.LogCall(req.Method, req.RequestURI, "200")
+	util.LogCall(req.Method, req.RequestURI, "200", false)
 }
 
 // GetFellowLinesOfCodeInPRs Get the additions and deletions of all
@@ -73,7 +72,7 @@ func GetFellowLinesOfCodeInPRs(w http.ResponseWriter, req *http.Request) {
 
 	// If user wasn't already queried and the cache doesn't exist then
 	// we call the API and cache the result
-	if !util.CheckUser(vars["username"], "prContributions.json") {
+	if !util.CheckUser(vars["username"], "PRContributions.json") {
 
 		client := util.SetupOAuth()
 		tempStruct, variables := util.Setup(vars["username"])
@@ -86,11 +85,11 @@ func GetFellowLinesOfCodeInPRs(w http.ResponseWriter, req *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(tempStruct.PRContributions)
-		util.LogCall(req.Method, req.RequestURI, "200")
+		util.LogCall(req.Method, req.RequestURI, "200", false)
 		return
 	}
 	// Serve from cache instead
-	content, err := util.ServeCache(vars["username"], "prContributions")
+	content, err := util.ServeCache(vars["username"], "PRContributions")
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -99,14 +98,13 @@ func GetFellowLinesOfCodeInPRs(w http.ResponseWriter, req *http.Request) {
 			Body:   fmt.Sprint(err),
 		}
 		json.NewEncoder(w).Encode(res)
-
-		util.LogCall(req.Method, req.RequestURI, "401")
+		util.LogCall(req.Method, req.RequestURI, "401", false)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200")
+	util.LogCall(req.Method, req.RequestURI, "200", true)
 
 }
 
@@ -127,7 +125,7 @@ func GetFellowPullRequestCommits(w http.ResponseWriter, req *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(tempStruct.PRCommits)
-		util.LogCall(req.Method, req.RequestURI, "200")
+		util.LogCall(req.Method, req.RequestURI, "200", false)
 		return
 	}
 	// Serve from cache instead
@@ -140,14 +138,13 @@ func GetFellowPullRequestCommits(w http.ResponseWriter, req *http.Request) {
 			Body:   fmt.Sprint(err),
 		}
 		json.NewEncoder(w).Encode(res)
-
-		util.LogCall(req.Method, req.RequestURI, "401")
+		util.LogCall(req.Method, req.RequestURI, "401", false)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200")
+	util.LogCall(req.Method, req.RequestURI, "200", true)
 
 }
 
@@ -169,7 +166,7 @@ func GetFellowRepoContributions(w http.ResponseWriter, req *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(tempStruct.RepoContrib)
-		util.LogCall(req.Method, req.RequestURI, "200")
+		util.LogCall(req.Method, req.RequestURI, "200", false)
 		return
 	}
 
@@ -183,14 +180,13 @@ func GetFellowRepoContributions(w http.ResponseWriter, req *http.Request) {
 			Body:   fmt.Sprint(err),
 		}
 		json.NewEncoder(w).Encode(res)
-
-		util.LogCall(req.Method, req.RequestURI, "401")
+		util.LogCall(req.Method, req.RequestURI, "401", false)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200")
+	util.LogCall(req.Method, req.RequestURI, "200", true)
 
 }
 
@@ -211,10 +207,9 @@ func GetFellowPullRequests(w http.ResponseWriter, req *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(tempStruct.Pr)
-		util.LogCall(req.Method, req.RequestURI, "200")
+		util.LogCall(req.Method, req.RequestURI, "200", false)
 		return
 	}
-
 	// Serve from cache instead
 	content, err := util.ServeCache(vars["username"], "pullRequests")
 	if err != nil {
@@ -225,14 +220,13 @@ func GetFellowPullRequests(w http.ResponseWriter, req *http.Request) {
 			Body:   fmt.Sprint(err),
 		}
 		json.NewEncoder(w).Encode(res)
-
-		util.LogCall(req.Method, req.RequestURI, "401")
+		util.LogCall(req.Method, req.RequestURI, "401", false)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200")
+	util.LogCall(req.Method, req.RequestURI, "200", true)
 
 }
 
@@ -253,7 +247,7 @@ func GetFellowIssuesCreated(w http.ResponseWriter, req *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(tempStruct.IssCreated)
-		util.LogCall(req.Method, req.RequestURI, "200")
+		util.LogCall(req.Method, req.RequestURI, "200", false)
 		return
 	}
 	// Serve from cache instead
@@ -266,14 +260,13 @@ func GetFellowIssuesCreated(w http.ResponseWriter, req *http.Request) {
 			Body:   fmt.Sprint(err),
 		}
 		json.NewEncoder(w).Encode(res)
-
-		util.LogCall(req.Method, req.RequestURI, "401")
+		util.LogCall(req.Method, req.RequestURI, "401", false)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200")
+	util.LogCall(req.Method, req.RequestURI, "200", true)
 
 }
 
@@ -294,10 +287,10 @@ func GetFellowAccountInfo(w http.ResponseWriter, req *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(tempStruct.AccountInfo)
-		util.LogCall(req.Method, req.RequestURI, "200")
+		util.LogCall(req.Method, req.RequestURI, "200", false)
 		return
 	}
-
+	// Serve from cache instead
 	content, err := util.ServeCache(vars["username"], "accountInfo")
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
@@ -307,12 +300,12 @@ func GetFellowAccountInfo(w http.ResponseWriter, req *http.Request) {
 			Body:   fmt.Sprint(err),
 		}
 		json.NewEncoder(w).Encode(res)
-		util.LogCall(req.Method, req.RequestURI, "401")
+		util.LogCall(req.Method, req.RequestURI, "401", false)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200")
+	util.LogCall(req.Method, req.RequestURI, "200", true)
 
 }

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -18,8 +20,8 @@ type response struct {
 }
 
 // VerificationMiddleware is a middlware to handle authentication
-// and checking if the username is valid before being passed onto
-// the requested endpoint
+// and checking if the username and query type is valid before being
+// passed onto the requested endpoint
 func VerificationMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
@@ -34,23 +36,37 @@ func VerificationMiddleware(next http.Handler) http.Handler {
 				Body:   fmt.Sprint(err),
 			}
 			json.NewEncoder(w).Encode(res)
-
 			util.LogCall(r.Method, r.RequestURI, "401", vars["startTime"], false)
 			return
 		}
 
-		if v, err := util.IsValidUsername(vars["username"]); !v {
+		if validUsername := util.IsValidUsername(vars["username"]); !validUsername {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
 			res := response{
 				Status: "422",
-				Body:   fmt.Sprint(err),
+				Body:   "Invalid username given",
 			}
 			json.NewEncoder(w).Encode(res)
 			util.LogCall(r.Method, r.RequestURI, "400", vars["startTime"], false)
 			return
 		}
 
+		fileName, err := util.IsValidQueryType(vars["query"])
+		if err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			res := response{
+				Status: "401",
+				Body:   fmt.Sprint(err),
+			}
+			json.NewEncoder(w).Encode(res)
+			util.LogCall(r.Method, r.RequestURI, "401", vars["startTime"], false)
+			return
+		}
+
+		vars["fileName"] = strings.ToLower(fileName)
+		vars["query"] = strings.ToLower(vars["query"])
 		next.ServeHTTP(w, r)
 
 	})
@@ -70,31 +86,55 @@ func HomeHandler(w http.ResponseWriter, req *http.Request) {
 	util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], false)
 }
 
-// GetFellowLinesOfCodeInPRs Get the additions and deletions of all
-// PRs for a given user
-func GetFellowLinesOfCodeInPRs(w http.ResponseWriter, req *http.Request) {
+func Query(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 
-	// If user wasn't already queried and the cache doesn't exist then
-	// we call the API and cache the result
-	if !util.CheckUser(vars["username"], "PRContributions.json") {
+	// Call the GitHub API and cache the result
+	if !util.CacheExists(vars["username"], vars["fileName"]) {
 
 		client := util.SetupOAuth()
-		tempStruct, variables := util.Setup(vars["username"])
+		dataStruct, variables := util.GetStruct(vars["query"], vars["username"])
+		if dataStruct == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			res := response{
+				Status: "401",
+				Body:   fmt.Sprint("Invalid query type given"),
+			}
+			json.NewEncoder(w).Encode(res)
+			util.LogCall(req.Method, req.RequestURI, "401", vars["startTime"], false)
+			return
+		}
 
-		// Call the API
-		err := client.Query(context.Background(), &tempStruct.PRContributions, variables)
-		util.CheckAPICallErr(err)
+		err := client.Query(context.Background(), dataStruct, variables)
+		err = util.CheckAPICallErr(err)
+		if err != nil {
+			// This catches errors thrown due to invalid usernames which is rare if not caught by the
+			// verification middleware
+			match, err := regexp.MatchString(`(Could not resolve to a User  with the login of \')(.)+(\')`, err.Error())
+			if err != nil && !match {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				res := response{
+					Status: "401",
+					Body:   fmt.Sprint("Invalid username given"),
+				}
+				json.NewEncoder(w).Encode(res)
+				util.LogCall(req.Method, req.RequestURI, "401", vars["startTime"], false)
+				return
+			}
+		}
 
-		util.WriteCache(vars["username"], "PRContributions", tempStruct.PRContributions)
+		util.WriteCache(vars["username"], vars["query"], dataStruct)
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(tempStruct.PRContributions)
+		json.NewEncoder(w).Encode(dataStruct)
+
 		util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], false)
 		return
 	}
 	// Serve from cache instead
-	content, err := util.ServeCache(vars["username"], "PRContributions")
+	content, err := util.GetCache(vars["username"], vars["fileName"])
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -107,207 +147,6 @@ func GetFellowLinesOfCodeInPRs(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], true)
-
-}
-
-// GetFellowPullRequestCommits gets the commits from pull requests
-func GetFellowPullRequestCommits(w http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-
-	if !util.CheckUser(vars["username"], "prCommits.json") {
-
-		client := util.SetupOAuth()
-		tempStruct, variables := util.Setup(vars["username"])
-
-		// Call the API
-		err := client.Query(context.Background(), &tempStruct.PRCommits, variables)
-		util.CheckAPICallErr(err)
-
-		util.WriteCache(vars["username"], "prCommits", tempStruct.PRCommits)
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(tempStruct.PRCommits)
-		util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], false)
-		return
-	}
-	// Serve from cache instead
-	content, err := util.ServeCache(vars["username"], "prCommits")
-	if err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		res := response{
-			Status: "401",
-			Body:   fmt.Sprint(err),
-		}
-		json.NewEncoder(w).Encode(res)
-		util.LogCall(req.Method, req.RequestURI, "401", vars["startTime"], false)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], true)
-
-}
-
-// GetFellowRepoContributions get a list of all repositories a user has
-// contributed to
-func GetFellowRepoContributions(w http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-
-	if !util.CheckUser(vars["username"], "repoContribs.json") {
-
-		client := util.SetupOAuth()
-		tempStruct, variables := util.Setup(vars["username"])
-
-		// Call the API
-		err := client.Query(context.Background(), &tempStruct.RepoContrib, variables)
-		util.CheckAPICallErr(err)
-
-		util.WriteCache(vars["username"], "repoContribs", tempStruct.RepoContrib)
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(tempStruct.RepoContrib)
-		util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], false)
-		return
-	}
-
-	// Serve from cache instead
-	content, err := util.ServeCache(vars["username"], "repoContribs")
-	if err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		res := response{
-			Status: "401",
-			Body:   fmt.Sprint(err),
-		}
-		json.NewEncoder(w).Encode(res)
-		util.LogCall(req.Method, req.RequestURI, "401", vars["startTime"], false)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], true)
-
-}
-
-// GetFellowPullRequests get a list of the most recent PRs made by a user
-func GetFellowPullRequests(w http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-
-	if !util.CheckUser(vars["username"], "pullRequests.json") {
-
-		client := util.SetupOAuth()
-		tempStruct, variables := util.Setup(vars["username"])
-
-		// Call the API
-		err := client.Query(context.Background(), &tempStruct.Pr, variables)
-		util.CheckAPICallErr(err)
-
-		util.WriteCache(vars["username"], "pullRequests", tempStruct.Pr)
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(tempStruct.Pr)
-		util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], false)
-		return
-	}
-	// Serve from cache instead
-	content, err := util.ServeCache(vars["username"], "pullRequests")
-	if err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		res := response{
-			Status: "401",
-			Body:   fmt.Sprint(err),
-		}
-		json.NewEncoder(w).Encode(res)
-		util.LogCall(req.Method, req.RequestURI, "401", vars["startTime"], false)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], true)
-
-}
-
-// GetFellowIssuesCreated get a list of the recent issues created by a user
-func GetFellowIssuesCreated(w http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-
-	if !util.CheckUser(vars["username"], "issuesCreated.json") {
-
-		client := util.SetupOAuth()
-		tempStruct, variables := util.Setup(vars["username"])
-
-		// Call the API
-		err := client.Query(context.Background(), &tempStruct.IssCreated, variables)
-		util.CheckAPICallErr(err)
-
-		util.WriteCache(vars["username"], "issuesCreated", &tempStruct.IssCreated)
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(tempStruct.IssCreated)
-		util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], false)
-		return
-	}
-	// Serve from cache instead
-	content, err := util.ServeCache(vars["username"], "issuesCreated")
-	if err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		res := response{
-			Status: "401",
-			Body:   fmt.Sprint(err),
-		}
-		json.NewEncoder(w).Encode(res)
-		util.LogCall(req.Method, req.RequestURI, "401", vars["startTime"], false)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], true)
-
-}
-
-// GetFellowAccountInfo get account information for a given user
-func GetFellowAccountInfo(w http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-
-	if !util.CheckUser(vars["username"], "accountInfo.json") {
-
-		client := util.SetupOAuth()
-		tempStruct, variables := util.Setup(vars["username"])
-
-		// Call the API
-		err := client.Query(context.Background(), &tempStruct.AccountInfo, variables)
-		util.CheckAPICallErr(err)
-
-		util.WriteCache(vars["username"], "accountInfo", tempStruct.AccountInfo)
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(tempStruct.AccountInfo)
-		util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], false)
-		return
-	}
-	// Serve from cache instead
-	content, err := util.ServeCache(vars["username"], "accountInfo")
-	if err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		res := response{
-			Status: "401",
-			Body:   fmt.Sprint(err),
-		}
-		json.NewEncoder(w).Encode(res)
-		util.LogCall(req.Method, req.RequestURI, "401", vars["startTime"], false)
-		return
-	}
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, content)
 	util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], true)

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/gorilla/mux"
 )
@@ -21,6 +23,8 @@ type response struct {
 func VerificationMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
+		startTime := time.Now().UnixNano() / int64(time.Millisecond)
+		vars["startTime"] = strconv.FormatInt(startTime, 10)
 
 		if auth, err := util.IsAuthorized(w, r); !auth {
 			w.Header().Set("Content-Type", "application/json")
@@ -31,7 +35,7 @@ func VerificationMiddleware(next http.Handler) http.Handler {
 			}
 			json.NewEncoder(w).Encode(res)
 
-			util.LogCall(r.Method, r.RequestURI, "401", false)
+			util.LogCall(r.Method, r.RequestURI, "401", vars["startTime"], false)
 			return
 		}
 
@@ -43,7 +47,7 @@ func VerificationMiddleware(next http.Handler) http.Handler {
 				Body:   fmt.Sprint(err),
 			}
 			json.NewEncoder(w).Encode(res)
-			util.LogCall(r.Method, r.RequestURI, "400", false)
+			util.LogCall(r.Method, r.RequestURI, "400", vars["startTime"], false)
 			return
 		}
 
@@ -54,6 +58,7 @@ func VerificationMiddleware(next http.Handler) http.Handler {
 
 // HomeHandler serves the content for the home page
 func HomeHandler(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
 	res := response{
 		Status: "success",
 		Body:   "Home page",
@@ -62,7 +67,7 @@ func HomeHandler(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(res)
-	util.LogCall(req.Method, req.RequestURI, "200", false)
+	util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], false)
 }
 
 // GetFellowLinesOfCodeInPRs Get the additions and deletions of all
@@ -85,7 +90,7 @@ func GetFellowLinesOfCodeInPRs(w http.ResponseWriter, req *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(tempStruct.PRContributions)
-		util.LogCall(req.Method, req.RequestURI, "200", false)
+		util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], false)
 		return
 	}
 	// Serve from cache instead
@@ -98,13 +103,13 @@ func GetFellowLinesOfCodeInPRs(w http.ResponseWriter, req *http.Request) {
 			Body:   fmt.Sprint(err),
 		}
 		json.NewEncoder(w).Encode(res)
-		util.LogCall(req.Method, req.RequestURI, "401", false)
+		util.LogCall(req.Method, req.RequestURI, "401", vars["startTime"], false)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200", true)
+	util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], true)
 
 }
 
@@ -125,7 +130,7 @@ func GetFellowPullRequestCommits(w http.ResponseWriter, req *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(tempStruct.PRCommits)
-		util.LogCall(req.Method, req.RequestURI, "200", false)
+		util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], false)
 		return
 	}
 	// Serve from cache instead
@@ -138,13 +143,13 @@ func GetFellowPullRequestCommits(w http.ResponseWriter, req *http.Request) {
 			Body:   fmt.Sprint(err),
 		}
 		json.NewEncoder(w).Encode(res)
-		util.LogCall(req.Method, req.RequestURI, "401", false)
+		util.LogCall(req.Method, req.RequestURI, "401", vars["startTime"], false)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200", true)
+	util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], true)
 
 }
 
@@ -166,7 +171,7 @@ func GetFellowRepoContributions(w http.ResponseWriter, req *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(tempStruct.RepoContrib)
-		util.LogCall(req.Method, req.RequestURI, "200", false)
+		util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], false)
 		return
 	}
 
@@ -180,13 +185,13 @@ func GetFellowRepoContributions(w http.ResponseWriter, req *http.Request) {
 			Body:   fmt.Sprint(err),
 		}
 		json.NewEncoder(w).Encode(res)
-		util.LogCall(req.Method, req.RequestURI, "401", false)
+		util.LogCall(req.Method, req.RequestURI, "401", vars["startTime"], false)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200", true)
+	util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], true)
 
 }
 
@@ -207,7 +212,7 @@ func GetFellowPullRequests(w http.ResponseWriter, req *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(tempStruct.Pr)
-		util.LogCall(req.Method, req.RequestURI, "200", false)
+		util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], false)
 		return
 	}
 	// Serve from cache instead
@@ -220,13 +225,13 @@ func GetFellowPullRequests(w http.ResponseWriter, req *http.Request) {
 			Body:   fmt.Sprint(err),
 		}
 		json.NewEncoder(w).Encode(res)
-		util.LogCall(req.Method, req.RequestURI, "401", false)
+		util.LogCall(req.Method, req.RequestURI, "401", vars["startTime"], false)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200", true)
+	util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], true)
 
 }
 
@@ -247,7 +252,7 @@ func GetFellowIssuesCreated(w http.ResponseWriter, req *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(tempStruct.IssCreated)
-		util.LogCall(req.Method, req.RequestURI, "200", false)
+		util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], false)
 		return
 	}
 	// Serve from cache instead
@@ -260,13 +265,13 @@ func GetFellowIssuesCreated(w http.ResponseWriter, req *http.Request) {
 			Body:   fmt.Sprint(err),
 		}
 		json.NewEncoder(w).Encode(res)
-		util.LogCall(req.Method, req.RequestURI, "401", false)
+		util.LogCall(req.Method, req.RequestURI, "401", vars["startTime"], false)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200", true)
+	util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], true)
 
 }
 
@@ -287,7 +292,7 @@ func GetFellowAccountInfo(w http.ResponseWriter, req *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(tempStruct.AccountInfo)
-		util.LogCall(req.Method, req.RequestURI, "200", false)
+		util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], false)
 		return
 	}
 	// Serve from cache instead
@@ -300,12 +305,11 @@ func GetFellowAccountInfo(w http.ResponseWriter, req *http.Request) {
 			Body:   fmt.Sprint(err),
 		}
 		json.NewEncoder(w).Encode(res)
-		util.LogCall(req.Method, req.RequestURI, "401", false)
+		util.LogCall(req.Method, req.RequestURI, "401", vars["startTime"], false)
 		return
 	}
-
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, content)
-	util.LogCall(req.Method, req.RequestURI, "200", true)
+	util.LogCall(req.Method, req.RequestURI, "200", vars["startTime"], true)
 
 }

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"backend/queries"
 	"backend/util"
 	"context"
 	"encoding/json"
@@ -9,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	"github.com/shurcooL/graphql"
 )
 
 type response struct {
@@ -76,13 +74,9 @@ func GetFellowLinesOfCodeInPRs(w http.ResponseWriter, req *http.Request) {
 	// If user wasn't already queried and the cache doesn't exist then
 	// we call the API and cache the result
 	if !util.CheckUser(vars["username"], "prContributions.json") {
+
 		client := util.SetupOAuth()
-
-		tempStruct := &queries.MegaJSONStruct{}
-
-		variables := map[string]interface{}{
-			"username": graphql.String(vars["username"]),
-		}
+		tempStruct, variables := util.Setup(vars["username"])
 
 		// Call the API
 		err := client.Query(context.Background(), &tempStruct.PRContributions, variables)
@@ -121,13 +115,9 @@ func GetFellowPullRequestCommits(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 
 	if !util.CheckUser(vars["username"], "prCommits.json") {
+
 		client := util.SetupOAuth()
-
-		tempStruct := &queries.MegaJSONStruct{}
-
-		variables := map[string]interface{}{
-			"username": graphql.String(vars["username"]),
-		}
+		tempStruct, variables := util.Setup(vars["username"])
 
 		// Call the API
 		err := client.Query(context.Background(), &tempStruct.PRCommits, variables)
@@ -167,13 +157,9 @@ func GetFellowRepoContributions(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 
 	if !util.CheckUser(vars["username"], "repoContribs.json") {
+
 		client := util.SetupOAuth()
-
-		tempStruct := &queries.MegaJSONStruct{}
-
-		variables := map[string]interface{}{
-			"username": graphql.String(vars["username"]),
-		}
+		tempStruct, variables := util.Setup(vars["username"])
 
 		// Call the API
 		err := client.Query(context.Background(), &tempStruct.RepoContrib, variables)
@@ -213,13 +199,9 @@ func GetFellowPullRequests(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 
 	if !util.CheckUser(vars["username"], "pullRequests.json") {
+
 		client := util.SetupOAuth()
-
-		tempStruct := &queries.MegaJSONStruct{}
-
-		variables := map[string]interface{}{
-			"username": graphql.String(vars["username"]),
-		}
+		tempStruct, variables := util.Setup(vars["username"])
 
 		// Call the API
 		err := client.Query(context.Background(), &tempStruct.Pr, variables)
@@ -259,13 +241,9 @@ func GetFellowIssuesCreated(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 
 	if !util.CheckUser(vars["username"], "issuesCreated.json") {
+
 		client := util.SetupOAuth()
-
-		tempStruct := &queries.MegaJSONStruct{}
-
-		variables := map[string]interface{}{
-			"username": graphql.String(vars["username"]),
-		}
+		tempStruct, variables := util.Setup(vars["username"])
 
 		// Call the API
 		err := client.Query(context.Background(), &tempStruct.IssCreated, variables)
@@ -304,13 +282,9 @@ func GetFellowAccountInfo(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 
 	if !util.CheckUser(vars["username"], "accountInfo.json") {
+
 		client := util.SetupOAuth()
-
-		tempStruct := &queries.MegaJSONStruct{}
-
-		variables := map[string]interface{}{
-			"username": graphql.String(vars["username"]),
-		}
+		tempStruct, variables := util.Setup(vars["username"])
 
 		// Call the API
 		err := client.Query(context.Background(), &tempStruct.AccountInfo, variables)

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -76,8 +76,7 @@ func GetFellowLinesOfCodeInPRs(w http.ResponseWriter, req *http.Request) {
 	// If user wasn't already queried and the cache doesn't exist then
 	// we call the API and cache the result
 	if !util.CheckUser(vars["username"], "prContributions.json") {
-		httpClient := util.SetupOAuth()
-		client := graphql.NewClient("https://api.github.com/graphql", httpClient)
+		client := util.SetupOAuth()
 
 		tempStruct := &queries.MegaJSONStruct{}
 
@@ -122,8 +121,7 @@ func GetFellowPullRequestCommits(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 
 	if !util.CheckUser(vars["username"], "prCommits.json") {
-		httpClient := util.SetupOAuth()
-		client := graphql.NewClient("https://api.github.com/graphql", httpClient)
+		client := util.SetupOAuth()
 
 		tempStruct := &queries.MegaJSONStruct{}
 
@@ -169,8 +167,7 @@ func GetFellowRepoContributions(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 
 	if !util.CheckUser(vars["username"], "repoContribs.json") {
-		httpClient := util.SetupOAuth()
-		client := graphql.NewClient("https://api.github.com/graphql", httpClient)
+		client := util.SetupOAuth()
 
 		tempStruct := &queries.MegaJSONStruct{}
 
@@ -216,8 +213,7 @@ func GetFellowPullRequests(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 
 	if !util.CheckUser(vars["username"], "pullRequests.json") {
-		httpClient := util.SetupOAuth()
-		client := graphql.NewClient("https://api.github.com/graphql", httpClient)
+		client := util.SetupOAuth()
 
 		tempStruct := &queries.MegaJSONStruct{}
 
@@ -263,9 +259,7 @@ func GetFellowIssuesCreated(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 
 	if !util.CheckUser(vars["username"], "issuesCreated.json") {
-
-		httpClient := util.SetupOAuth()
-		client := graphql.NewClient("https://api.github.com/graphql", httpClient)
+		client := util.SetupOAuth()
 
 		tempStruct := &queries.MegaJSONStruct{}
 
@@ -310,9 +304,7 @@ func GetFellowAccountInfo(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 
 	if !util.CheckUser(vars["username"], "accountInfo.json") {
-		fmt.Println("Calling API")
-		httpClient := util.SetupOAuth()
-		client := graphql.NewClient("https://api.github.com/graphql", httpClient)
+		client := util.SetupOAuth()
 
 		tempStruct := &queries.MegaJSONStruct{}
 

--- a/backend/util/util.go
+++ b/backend/util/util.go
@@ -178,3 +178,15 @@ func WriteCache(username, filename string, data interface{}) {
 	}
 	_ = ioutil.WriteFile(fileLocation, jsonData, 0777)
 }
+
+// ServeCache serves the cached result for a given user and filename
+func ServeCache(username, filename string) (string, error) {
+
+	fileLocation := fmt.Sprintf("../data/%s/%s.json", username, filename)
+	content, err := ioutil.ReadFile(fileLocation)
+	if err != nil {
+		return "", errors.New("Invalid username given, cache not found")
+	}
+
+	return string(content), nil
+}

--- a/backend/util/util.go
+++ b/backend/util/util.go
@@ -97,8 +97,12 @@ func SetupOAuth() *graphql.Client {
 	return client
 }
 
-func LogCall(method, endpoint, status string) {
+func LogCall(method, endpoint, status string, cached bool) {
 	statusColor := "\033[0m"
+	cacheString := ""
+	if cached {
+		cacheString = "[CACHE] "
+	}
 
 	// If the HTTP status given is 2XX, give it a nice
 	// green color, otherwise give it a red color
@@ -107,7 +111,7 @@ func LogCall(method, endpoint, status string) {
 	} else {
 		statusColor = "\033[31m"
 	}
-	fmt.Printf("[%s] %s %s %s%s%s\n", time.Now().Format("02-Jan-2006 15:04:05"), method, endpoint, statusColor, status, "\033[0m")
+	fmt.Printf("[%s]%s%s %s %s%s%s\n", time.Now().Format("02-Jan-2006 15:04:05"), cacheString, method, endpoint, statusColor, status, "\033[0m")
 }
 
 // IsValidUsername checks if a gihub username exists

--- a/backend/util/util.go
+++ b/backend/util/util.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -97,12 +98,20 @@ func SetupOAuth() *graphql.Client {
 	return client
 }
 
-func LogCall(method, endpoint, status string, cached bool) {
+func LogCall(method, endpoint, status, startTimeString string, cached bool) {
 	statusColor := "\033[0m"
 	cacheString := ""
+
 	if cached {
 		cacheString = "[CACHE] "
 	}
+
+	startTime, err := strconv.ParseInt(startTimeString, 10, 64)
+	if err != nil {
+		startTime = -1
+	}
+	endTime := time.Now().UnixNano() / int64(time.Millisecond)
+	delay := endTime - startTime
 
 	// If the HTTP status given is 2XX, give it a nice
 	// green color, otherwise give it a red color
@@ -111,7 +120,7 @@ func LogCall(method, endpoint, status string, cached bool) {
 	} else {
 		statusColor = "\033[31m"
 	}
-	fmt.Printf("[%s]%s%s %s %s%s%s\n", time.Now().Format("02-Jan-2006 15:04:05"), cacheString, method, endpoint, statusColor, status, "\033[0m")
+	fmt.Printf("[%s]%s%s %s %s%s%s %dms\n", time.Now().Format("02-Jan-2006 15:04:05"), cacheString, method, endpoint, statusColor, status, "\033[0m", delay)
 }
 
 // IsValidUsername checks if a gihub username exists

--- a/backend/util/util.go
+++ b/backend/util/util.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -160,4 +161,20 @@ func IsAuthorized(w http.ResponseWriter, r *http.Request) (bool, error) {
 		return false, errors.New("Incorrect 'secret'")
 	}
 	return true, nil
+}
+
+// WriteCache writes a struct to it's associated cache file for
+// a given user
+func WriteCache(username, filename string, data interface{}) {
+	// Write to JSON file
+	dirLocation := fmt.Sprintf("../data/%s", username)
+	_ = os.Mkdir(dirLocation, 0755)
+
+	fileLocation := fmt.Sprintf("../data/%s/%s.json", username, filename)
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		log.Fatal(err)
+	}
+	_ = ioutil.WriteFile(fileLocation, jsonData, 0777)
 }

--- a/backend/util/util.go
+++ b/backend/util/util.go
@@ -87,12 +87,13 @@ func CheckUser(username, fileName string) bool {
 }
 
 // SetupOAuth test
-func SetupOAuth() *http.Client {
+func SetupOAuth() *graphql.Client {
 	src := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: os.Getenv("GRAPHQL_TOKEN")},
 	)
 	httpClient := oauth2.NewClient(context.Background(), src)
-	return httpClient
+	client := graphql.NewClient("https://api.github.com/graphql", httpClient)
+	return client
 }
 
 func LogCall(method, endpoint, status string) {
@@ -120,8 +121,8 @@ func IsValidUsername(username string) (bool, error) {
 	}
 
 	// Check if username exists in github database
-	httpClient := SetupOAuth()
-	client := graphql.NewClient("https://api.github.com/graphql", httpClient)
+	client := SetupOAuth()
+
 	var tempStruct struct {
 		User struct {
 			Login graphql.String

--- a/backend/util/util.go
+++ b/backend/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"backend/queries"
 	"context"
 	"encoding/json"
 	"errors"
@@ -190,4 +191,16 @@ func ServeCache(username, filename string) (string, error) {
 	}
 
 	return string(content), nil
+}
+
+// Setup Returns the struct for JSON unmarshalling and graphQL call asiases
+// used for every call to the API
+func Setup(username string) (*queries.MegaJSONStruct, map[string]interface{}) {
+	tempStruct := &queries.MegaJSONStruct{}
+
+	variables := map[string]interface{}{
+		"username": graphql.String(username),
+	}
+
+	return tempStruct, variables
 }


### PR DESCRIPTION
This PR is in response to issue https://github.com/MLH-Fellowship/FellowshipWrapup/issues/34

* Add `writeCache` func to reduce code duplication on every route.
* Add `ServeCache` func to reduce code duplication on every route
* Moved the whole graphQL.Client setup into it's own func to further reduce code duplication
* Add the setup lines to their own func to further reduce duplication
* Add cache flag to indicate in the logs which requests hit the cache instead of the API
* Add delay time logging to requests